### PR TITLE
Fix utf8String casting exception

### DIFF
--- a/src/main/scala/org/apache/spark/sql/streaming/examples/KafkaDDL.scala
+++ b/src/main/scala/org/apache/spark/sql/streaming/examples/KafkaDDL.scala
@@ -21,9 +21,10 @@ import org.apache.spark.sql.{SQLContext, Row}
 import org.apache.spark.sql.streaming.StreamSQLContext
 import org.apache.spark.sql.streaming.sources.MessageToRowConverter
 import org.apache.spark.streaming.{Duration, StreamingContext}
+import org.apache.spark.unsafe.types.UTF8String
 
 class MessageDelimiter extends MessageToRowConverter {
-  def toRow(msg: String): Row = Row(msg)
+  def toRow(msg: UTF8String): Row = Row(msg)
 }
 
 object KafkaDDL {

--- a/src/main/scala/org/apache/spark/sql/streaming/sources/KafkaSource.scala
+++ b/src/main/scala/org/apache/spark/sql/streaming/sources/KafkaSource.scala
@@ -25,9 +25,10 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.streaming.dstream.DStream
 import org.apache.spark.streaming.kafka.KafkaUtils
+import org.apache.spark.unsafe.types.UTF8String
 
 trait MessageToRowConverter extends Serializable {
-  def toRow(message: String): Row
+  def toRow(message: UTF8String): Row
 }
 
 class KafkaSource extends SchemaRelationProvider {
@@ -106,5 +107,6 @@ case class KafkaRelation(
     StringDecoder
     ](streamSqlContext.streamingContext, kafkaParams, topics, StorageLevel.MEMORY_AND_DISK_SER_2)
 
-  @transient val stream: DStream[Row] = kafkaStream.map(_._2).map(messageToRowConverter.toRow)
+  @transient val stream: DStream[Row] = kafkaStream.map(_._2).map(
+    msg => messageToRowConverter.toRow(UTF8String.fromString(msg)))
 }

--- a/src/main/scala/org/apache/spark/sql/streaming/sources/SocketTextSource.scala
+++ b/src/main/scala/org/apache/spark/sql/streaming/sources/SocketTextSource.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.sources.{BaseRelation, SchemaRelationProvider}
 import org.apache.spark.sql.streaming.StreamPlan
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.streaming.dstream.DStream
+import org.apache.spark.unsafe.types.UTF8String
 
 class SocketTextSource extends SchemaRelationProvider {
   override def createRelation(
@@ -71,6 +72,7 @@ case class SocketTextRelation(
   @transient private val socketStream = streamSqlContext.streamingContext.socketTextStream(
     host, port)
 
-  @transient val stream: DStream[Row] = socketStream.map(messageToRowConverter.toRow)
+  @transient val stream: DStream[Row] = socketStream.map(msg =>
+    messageToRowConverter.toRow(UTF8String.fromString(msg)))
 }
 


### PR DESCRIPTION
https://github.com/Intel-bigdata/spark-streamingsql/issues/17

WARN TaskSetManager: Lost task 0.0 in stage 11.0 (TID 871, xa36502.eng.platformlab.ibm.com): java.lang.ClassCastException: java.lang.String cannot be cast to org.apache.spark.sql.types.UTF8String